### PR TITLE
hotfix: fix deployment ip challenges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,4 @@ RUN php artisan key:generate
 EXPOSE 8000
 
 # run application
-CMD php artisan serve --port=8000
+CMD php artisan serve --host=0.0.0.0 --port=8000


### PR DESCRIPTION
Apparently, the removal of the explicit host breaks the docker run. 
Hence the reason for putting it back in.